### PR TITLE
fix: support for urls without protocol

### DIFF
--- a/filters/all.js
+++ b/filters/all.js
@@ -118,6 +118,9 @@ function port(url, defaultPort) {
 filter.port = port;
 
 function stripProtocol(url) {
+  if(!url.includes('://')){
+    return url;
+  }
   const u = new URL(url);
   return url.substr(u.protocol.length + 2);
 }


### PR DESCRIPTION
**Description**

- this will fix the issue with URLs that do not contain a protocol at the start of the URL in AsyncAPI file.
- currently, this template will generate a Nodejs project with the wrong URL in the `config/common.yml` file.

**Related issue(s)**
Resolves #47 