### PR TITLE
fix: use errorLogger for outgoing messages

### DIFF
--- a/template/src/api/index.js
+++ b/template/src/api/index.js
@@ -31,6 +31,7 @@ app.useOutbound({{ channelName | camelCase }});
 {% endif -%}
 {% endfor %}
 app.use(errorLogger);
+app.useOutbound(errorLogger);
 app.useOutbound(logger);
 app.useOutbound(json2string);
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Recently we integrated message validator that validates both, incoming and outgoing messages, but  validation errors were thrown only on invalid incoming messages, not the outgoing ones