### PR TITLE
fix: use publish.message(0), subscribe.message(0), not .message() for oneOf…

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -39,6 +39,16 @@
         "doc",
         "code"
       ]
+    },
+    {
+      "login": "DavidBiesack",
+      "name": "David Biesack",
+      "avatar_url": "https://avatars.githubusercontent.com/u/545944?v=4",
+      "profile": "https://github.com/DavidBiesack",
+      "contributions": [
+        "bug",
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/nodejs-template",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Node.js template for the AsyncAPI generator.",
   "keywords": [
     "asyncapi",

--- a/template/src/api/routes/$$channel$$.js
+++ b/template/src/api/routes/$$channel$$.js
@@ -11,7 +11,7 @@ module.exports = router;
   {%- endif %}
 router.use('{{ channelName | toHermesTopic }}', async (message, next) => {
   try {
-    await validateMessage(message.payload,'{{ channelName }}','{{ channel.publish().message().name() }}','publish');
+    await validateMessage(message.payload,'{{ channelName }}','{{ channel.publish().message(0).name() }}','publish');
     await {{ channelName | camelCase }}Handler.{{ channel.publish().id() }}({message});
     next();
   } catch (e) {
@@ -28,7 +28,7 @@ router.use('{{ channelName | toHermesTopic }}', async (message, next) => {
   {%- endif %}
 router.useOutbound('{{ channelName | toHermesTopic }}', async (message, next) => {
   try {
-    await validateMessage(message.payload,'{{ channelName }}','{{ channel.subscribe().message().name() }}','subscribe');
+    await validateMessage(message.payload,'{{ channelName }}','{{ channel.subscribe().message(0).name() }}','subscribe');
     await {{ channelName | camelCase }}Handler.{{ channel.subscribe().id() }}({message});
     next();
   } catch (e) {


### PR DESCRIPTION
**Description**

Call subscribe.message(0) and subscribe.message(0); instead of .message().
This works for both operations defined with a single message schema,
or operations that use `oneOf`. 

The template still is incomplete; it does not fully support `oneOf`
(it should  use `hasMultipleMessages` to emit the right code ( https://github.com/asyncapi/parser-js/blob/master/lib/models/operation.js )

**Related issue(s)**

Fixes #62 