### PR TITLE
fix: issue 62/oneOf

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -39,6 +39,16 @@
         "doc",
         "code"
       ]
+    },
+    {
+      "login": "DavidBiesack",
+      "name": "David Biesack",
+      "avatar_url": "https://avatars.githubusercontent.com/u/545944?v=4",
+      "profile": "https://github.com/DavidBiesack",
+      "contributions": [
+        "bug",
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/nodejs-template",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/nodejs-template",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Node.js template for the AsyncAPI generator.",
   "keywords": [
     "asyncapi",

--- a/template/src/api/routes/$$channel$$.js
+++ b/template/src/api/routes/$$channel$$.js
@@ -3,6 +3,8 @@ const {validateMessage} = require('../../lib/message-validator');
 const router = new Router();
 const {{ channelName | camelCase }}Handler = require('../handlers/{{ channelName | convertToFilename }}');
 module.exports = router;
+
+
 {% if channel.hasPublish() %}
   {%- if channel.publish().summary() %}
 /**
@@ -11,9 +13,24 @@ module.exports = router;
   {%- endif %}
 router.use('{{ channelName | toHermesTopic }}', async (message, next) => {
   try {
-    await validateMessage(message.payload,'{{ channelName }}','{{ channel.publish().message(0).name() }}','publish');
+    {% if channel.publish().hasMultipleMessages() %}
+    let nValidated = 0;
+    // For oneOf, only one message schema should match.
+    // Validate payload against each message and count those which validate
+    {% for i in range(0, channel.publish().messages().length) -%}
+    nValidated = await validateMessage(message.payload,'{{ channelName }}','{{ channel.publish().message(i).name() }}','publish', nValidated);
+    {% endfor -%}
+    if (nValidated === 1) {
+      await {{ channelName | camelCase }}Handler.{{ channel.publish().id() }}({message});
+      next()
+    } else {
+      throw new Error(`${nValidated} of {{ channel.publish().messages().length }} message schemas matched when exactly 1 should match`);
+    }
+    {% else %}
+    await validateMessage(message.payload,'{{ channelName }}','{{ channel.publish().message().name() }}','publish');
     await {{ channelName | camelCase }}Handler.{{ channel.publish().id() }}({message});
     next();
+    {% endif %}
   } catch (e) {
     next(e);
   }
@@ -28,9 +45,24 @@ router.use('{{ channelName | toHermesTopic }}', async (message, next) => {
   {%- endif %}
 router.useOutbound('{{ channelName | toHermesTopic }}', async (message, next) => {
   try {
-    await validateMessage(message.payload,'{{ channelName }}','{{ channel.subscribe().message(0).name() }}','subscribe');
+    {% if channel.subscribe().hasMultipleMessages() %}
+    let nValidated = 0;
+    // For oneOf, only one message schema should match.
+    // Validate payload against each message and count those which validate
+    {% for i in range(0, channel.subscribe().messages().length) -%}
+    nValidated = await validateMessage(message.payload,'{{ channelName }}','{{ channel.subscribe().message(i).name() }}','subscribe', nValidated);
+    {% endfor -%}
+    if (nValidated === 1) {
+      await {{ channelName | camelCase }}Handler.{{ channel.subscribe().id() }}({message});
+      next()
+    } else {
+      throw new Error(`${nValidated} of {{ channel.subscribe().messages().length }} message schemas matched when exactly 1 should match`);
+    }
+    {% else %}
+    await validateMessage(message.payload,'{{ channelName }}','{{ channel.subscribe().message().name() }}','subscribe');
     await {{ channelName | camelCase }}Handler.{{ channel.subscribe().id() }}({message});
     next();
+    {% endif %}
   } catch (e) {
     next(e);
   }

--- a/template/src/api/routes/$$channel$$.js
+++ b/template/src/api/routes/$$channel$$.js
@@ -11,7 +11,7 @@ module.exports = router;
   {%- endif %}
 router.use('{{ channelName | toHermesTopic }}', async (message, next) => {
   try {
-    await validateMessage(message.payload,'{{ channelName }}','{{ channel.publish().message().name() }}','publish');
+    await validateMessage(message.payload,'{{ channelName }}','{{ channel.publish().message(0).name() }}','publish');
     await {{ channelName | camelCase }}Handler.{{ channel.publish().id() }}({message});
     next();
   } catch (e) {
@@ -28,7 +28,7 @@ router.use('{{ channelName | toHermesTopic }}', async (message, next) => {
   {%- endif %}
 router.useOutbound('{{ channelName | toHermesTopic }}', async (message, next) => {
   try {
-    await validateMessage(message.payload,'{{ channelName }}','{{ channel.subscribe().message().name() }}','subscribe');
+    await validateMessage(message.payload,'{{ channelName }}','{{ channel.subscribe().message(0).name() }}','subscribe');
     await {{ channelName | camelCase }}Handler.{{ channel.subscribe().id() }}({message});
     next();
   } catch (e) {

--- a/template/src/lib/message-validator.js
+++ b/template/src/lib/message-validator.js
@@ -1,6 +1,14 @@
 const AsyncApiValidator = require('asyncapi-validator');
 
-module.exports.validateMessage = async (payload, channel,name,operation)=> {
-  let va = await AsyncApiValidator.fromSource('./asyncapi.yaml', {msgIdentifier: 'name'});
-  va.validate(name, payload, channel, operation);
+module.exports.validateMessage = async (payload, channelName, messageName, operation, nValidated) => {
+  try {
+    let va = await AsyncApiValidator.fromSource('./asyncapi.yaml', {msgIdentifier: 'name'});
+    va.validate(messageName, payload, channelName, operation);
+    nValidated++;
+  } catch (e) {
+  }
+  if (nValidated > 1) {
+    throw new Error(`At least ${nValidated} message schema matched when exactly 1 should match`);
+  }
+  return nValdated;
 }


### PR DESCRIPTION
**Description**

Updated `$$channel$$.js` (and `lib/message-validator.js`) to support `oneOf:` messages

Modified the `validateMessage` function to validate the payload and if valid, increment and return a counter of validated messages. Ignore validation exceptions. Throw an exception only if `nValidated > 1`  (no need to try validating more - fail fast). `router` functions (publish or subscribe) try to validate the payload against all of the messages. If exactly one matches, then we proceed, else we stop.

I used this sample input to test code gen with both subscribe and publish

```yaml
asyncapi: '2.0.0'
info:
  title: Streetlights API
  version: '1.0.0'
  description: |
    The Smartylighting Streetlights API allows you
    to remotely manage the city lights.
  license:
    name: Apache 2.0
    url: 'https://www.apache.org/licenses/LICENSE-2.0'
servers:
  mosquitto:
    url: mqtt://test.mosquitto.org
    protocol: mqtt
channels:
  light/measured:
    publish:
      summary: Inform about environmental lighting conditions for a particular streetlight.
      operationId: pubLightMeasured
      message:
        oneOf:
          - name: LightMeasured
            payload:
              $ref: '#/components/schemas/LightMeasured'
          - name: LightFailure
            payload:
              $ref: '#/components/schemas/LightFailure'
    subscribe:
      summary: Inform about environmental lighting conditions for a particular streetlight.
      operationId: subLightMeasured
      message:
        oneOf:
          - name: LightMeasured
            payload:
              $ref: '#/components/schemas/LightMeasured'
          - name: LightFailure
            payload:
              $ref: '#/components/schemas/LightFailure'
components:
  schemas:
    LightMeasured:
      type: object
      required:
        - id
        - lumens
        - sentAt
      additionalProperties: false
      properties:
        id:
          type: integer
          minimum: 0
          description: Id of the streetlight.
        lumens:
          type: integer
          minimum: 0
          description: Light intensity measured in lumens.
        sentAt:
          type: string
          format: date-time
          description: Date and time when the message was sent.
    LightFailure:
      type: object
      required:
        - id
        - failedAt
        - sentAt
      additionalProperties: false
      properties:
        id:
          type: integer
          minimum: 0
          description: Id of the streetlight.
        failedAt:
          type: string
          format: date-time
          description: Date and time when the failure was detected.
        sentAt:
          type: string
          format: date-time
          description: Date and time when the message was sent.

```

This is the generated output from running
`ag --output sdk/nodejs asyncapi.yaml @asyncapi/nodejs-template -p server=mosquitto` :

```javascript
const Router = require('hermesjs/lib/router');
const {validateMessage} = require('../../lib/message-validator');
const router = new Router();
const lightMeasuredHandler = require('../handlers/light-measured');
module.exports = router;



/**
 * Inform about environmental lighting conditions for a particular streetlight.
 */
router.use('light/measured', async (message, next) => {
  try {
    
    let nValidated = 0;
    // For oneOf, only one message schema should match.
    // Validate payload against each message and count those which validate
    nValidated = await validateMessage(message.payload,'light/measured','LightMeasured','publish', nValidated);
    nValidated = await validateMessage(message.payload,'light/measured','LightFailure','publish', nValidated);
    if (nValidated === 1) {
      await lightMeasuredHandler.pubLightMeasured({message});
      next()
    } else {
      throw new Error(`${nValidated} of 2 message schemas matched when exactly 1 should match`);
    }
    
  } catch (e) {
    next(e);
  }
});
/**
 * Inform about environmental lighting conditions for a particular streetlight.
 */
router.useOutbound('light/measured', async (message, next) => {
  try {
    
    let nValidated = 0;
    // For oneOf, only one message schema should match.
    // Validate payload against each message and count those which validate
    nValidated = await validateMessage(message.payload,'light/measured','LightMeasured','subscribe', nValidated);
    nValidated = await validateMessage(message.payload,'light/measured','LightFailure','subscribe', nValidated);
    if (nValidated === 1) {
      await lightMeasuredHandler.subLightMeasured({message});
      next()
    } else {
      throw new Error(`${nValidated} of 2 message schemas matched when exactly 1 should match`);
    }
    
  } catch (e) {
    next(e);
  }
});
```
Possible enhancements: track which schemas validated to give better response to the caller via the exception.

**Related issue(s)**

Fixes #63