### PR TITLE
fix: use fixed version of color.js to avoid code broken in 1.4 patch

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -6,7 +6,7 @@
     "start": "node src/api/index.js"
   },
   "dependencies": {
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "dotenv": "^8.1.0",
     "hermesjs": "2.x",
     "hermesjs-router": "1.x",


### PR DESCRIPTION
background https://twitter.com/derberq/status/1480814592204972033 🤯 

tested fix locally and works like a charm

long term solution is to use different package -> https://github.com/asyncapi/nodejs-template/issues/110