### PR TITLE
fix: let validation throw an exception when payload is invalid

### DIFF
--- a/template/src/api/routes/$$channel$$.js
+++ b/template/src/api/routes/$$channel$$.js
@@ -24,7 +24,9 @@ router.use('{{ channelName | toHermesTopic }}', async (message, next) => {
     // For oneOf, only one message schema should match.
     // Validate payload against each message and count those which validate
     {% for i in range(0, channel.publish().messages().length) -%}
-    nValidated = await validateMessage(message.payload,'{{ channelName }}','{{ channel.publish().message(i).name() }}','publish', nValidated);
+    try {
+      nValidated = await validateMessage(message.payload,'{{ channelName }}','{{ channel.publish().message(i).name() }}','publish', nValidated);  
+    } catch { };
     {% endfor -%}
     if (nValidated === 1) {
       await {{ channelName | camelCase }}Handler.{{ channel.publish().id() }}({message});

--- a/template/src/lib/message-validator.js
+++ b/template/src/lib/message-validator.js
@@ -2,12 +2,9 @@ const AsyncApiValidator = require('asyncapi-validator');
 
 // Try to parse the payload, and increment nValidated if parsing was successful.
 module.exports.validateMessage = async (payload, channelName, messageName, operation, nValidated=0) => {
-  try {
-    const va = await AsyncApiValidator.fromSource('./asyncapi.yaml', {msgIdentifier: 'name'});
-    va.validate(messageName, payload, channelName, operation);
-    nValidated++;
-  } catch (e) {
-    return nValidated;
-  }
+  const va = await AsyncApiValidator.fromSource('./asyncapi.yaml', {msgIdentifier: 'name'});
+  va.validate(messageName, payload, channelName, operation);
+  nValidated++;
+  
   return nValidated;
 };


### PR DESCRIPTION
**Description**

The PR [feat: support oneOf in messages](https://github.com/asyncapi/nodejs-template/pull/82) introduced a `try/catch` block inside the message validator logic that is preventing now to properly throw an exception when the message payload is invalid. See this in particular https://github.com/asyncapi/nodejs-template/commit/df21f7ed8379d2dd74555e9fdd3cea9a387dfada#diff-f157162b6f22efb01592bb0d6a1f02f851a6d17d44606f0ef6398d135e9cc28bR5-R11
A `try/catch` block is needed in the case of handling multiple messages (`oneOf`), so instead of adding it to the validator, I added it to the call when validating multiple messages.

**Related issue(s)**
Damilola Oladele reported this bug via Slack. https://asyncapi.slack.com/archives/CQVJXFNQL/p1667713486493359

cc @DavidBiesack 