### PR TITLE
fix: adjust filters and config parsing for websocket protocol

### DIFF
--- a/filters/all.js
+++ b/filters/all.js
@@ -176,7 +176,11 @@ function getConfig(p) {
   let protocol = p;
   let configName = 'broker';
 
-  if (p === 'ws') configName = 'ws';
+  if (p === 'ws') {
+    configName = 'ws';
+    return `config.${configName}`;
+  }
+
   if (p === 'kafka-secure') protocol = 'kafka';
 
   return `config.${configName}.${protocol}`;

--- a/template/config/common.yml
+++ b/template/config/common.yml
@@ -4,7 +4,7 @@ default:
     version: {{ asyncapi.info().version() }}
 {% if asyncapi.server(params.server).protocol() === "ws" %}
   ws:
-    port: {{ asyncapi.server(params.server).url() | replaceVariablesWithValues(asyncapi.server(params.server).variables()) | port(80) }}
+    port: {{ asyncapi.server(params.server).url() | replaceServerVariablesWithValues(asyncapi.server(params.server).variables()) | port(80) }}
     path: /ws
     topicSeparator: '__'
 {% endif %}


### PR DESCRIPTION
error:
```
# asyncapi generate fromTemplate asyncapi.yaml @asyncapi/nodejs-template -o output -p server=dev
Generation in progress. Keep calm and wait a bit... done

Generator Error: (/usr/lib/node_modules/@asyncapi/cli/node_modules/@asyncapi/generator/node_modules/@asyncapi/nodejs-template/template/config/common.yml) [Line 4, Column 21]
  Error: filter not found: replaceVariablesWithValues
```

taken from https://asyncapi.slack.com/archives/CQVJXFNQL/p1680006402805839

it was broken long time ago in https://github.com/asyncapi/nodejs-template/pull/123 but just nobody used this template with websocket protocol, thus invalid filter was never called