### PR TITLE
fix: log the name of the message if it is absent

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-react": "^7.34.1",
     "filenamify": "^4.3.0",
     "js-beautify": "^1.15.1",
+    "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "markdown-toc": "^1.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -76,6 +76,10 @@
       "certFilesDir": {
         "description": "Directory where application certificates are located. This parameter is needed when you use X509 security scheme and your cert files are not located in the root of your application.",
         "default": "./"
+      },
+      "messageRuntimeValidation": {
+        "description": "Enable or disable runtime validation of message identifiers.",
+        "default": true
       }
     },
     "nonRenderableFiles": [

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "default": "./"
       },
       "messageRuntimeValidation": {
-        "description": "Enable or disable runtime validation of message identifiers.",
+        "description": "Enable or disable runtime validation of messages against schemas provided in AsyncAPI document.",
         "default": true
       }
     },

--- a/template/src/api/middlewares/error-logger.js
+++ b/template/src/api/middlewares/error-logger.js
@@ -1,8 +1,11 @@
-const { red, gray } = require('chalk');
+const { red, gray, green } = require('chalk');
 
 module.exports = (err, message, next) => {
   if (err.name === 'AsyncAPIValidationError') {
     console.error(red(`❗  Message Rejected. ${err.message}`));
+    if(err.warning) {
+      console.warn(green(`⛔ ${err.warning}`));
+    }
   } else {
     console.error(red(`❗  ${err.message}`));
     if (err.stack)

--- a/template/src/lib/message-validator.js
+++ b/template/src/lib/message-validator.js
@@ -1,5 +1,32 @@
+const yaml = require('js-yaml');
+const fs = require('fs');
 const path = require('path');
 const AsyncApiValidator = require('asyncapi-validator');
+
+function validateMessageIdentifiers(asyncApiSpec) {
+  const messages = asyncApiSpec.components.messages;
+  const missingNames = [];
+
+  for (const [messageName, messageObj] of Object.entries(messages)) {
+    if (!messageObj.name) {
+      missingNames.push(messageName);
+    }
+  }
+
+  return missingNames;
+}
+
+function performPreGenValidation(asyncApiFilePath) {
+  const fileContents = fs.readFileSync(asyncApiFilePath, 'utf8');
+  const asyncApiSpec = yaml.load(fileContents);
+
+  const missingNames = validateMessageIdentifiers(asyncApiSpec);
+
+  if (missingNames.length > 0) {
+    const errorMessage = `msgIdentifier "name" does not exist for message(s): ${missingNames.join(', ')}`;
+    throw new Error(errorMessage);
+  }
+}
 
 // Try to parse the payload, and increment nValidated if parsing was successful.
 module.exports.validateMessage = async (
@@ -9,12 +36,17 @@ module.exports.validateMessage = async (
   operation,
   nValidated = 0
 ) => {
-  const asyncApiFilePath = path.resolve(__dirname, '../../asyncapi.yaml');
-  const va = await AsyncApiValidator.fromSource(asyncApiFilePath, {
-    msgIdentifier: 'name',
-  });
-  va.validate(messageName, payload, channelName, operation);
-  nValidated++;
+  try {
+    const asyncApiFilePath = path.resolve(__dirname, "../../asyncapi.yaml");
+    const va = await AsyncApiValidator.fromSource(asyncApiFilePath, {
+      msgIdentifier: "name",
+    });
+    va.validate(messageName, payload, channelName, operation);
+    nValidated++;
 
-  return nValidated;
+    return nValidated;
+  } catch (error) {
+    error.name = "AsyncAPIValidationError";
+    throw error;
+  }
 };


### PR DESCRIPTION

**Description**
Added a param `messageRuntimeValidation`  which will log the messageId's if its missing and if false then it will not warn anything(by default it will be true)
![Screenshot from 2024-07-02 02-18-41](https://github.com/asyncapi/nodejs-template/assets/153212508/e700cf71-25b9-4df6-91bb-d0c3371c1397)
![image](https://github.com/asyncapi/nodejs-template/assets/153212508/45c4cfda-9e45-4452-be94-712e3ab9250f)

![image](https://github.com/asyncapi/nodejs-template/assets/153212508/dec53673-e90e-4c65-adaf-95fd3ffb6791)
![image](https://github.com/asyncapi/nodejs-template/assets/153212508/2cd47f92-59a9-4221-be36-66ea2d65077d)


**Related issue(s)**
#197 